### PR TITLE
gml:MultiGeometry support added

### DIFF
--- a/src/Format/Format.GML.js
+++ b/src/Format/Format.GML.js
@@ -23,6 +23,7 @@ L.Format.GML = L.Format.Base.extend({
     this.appendParser(new L.GML.MultiCurve());
     this.appendParser(new L.GML.MultiSurface());
     this.appendParser(new L.GML.MultiPoint());
+    this.appendParser(new L.GML.MultiGeometry());
   },
 
   /**

--- a/src/Format/Parsers/Layers/LineString.js
+++ b/src/Format/Parsers/Layers/LineString.js
@@ -7,6 +7,8 @@
 
 L.GML.LineString = L.GML.LineStringNode.extend({
 
+  elementTag: 'gml:LineString',
+
   includes: L.GML.CoordsToLatLngMixin,
 
   /**

--- a/src/Format/Parsers/Layers/MultiGeometry.js
+++ b/src/Format/Parsers/Layers/MultiGeometry.js
@@ -32,10 +32,16 @@
  */
 
 L.GML.MultiGeometry = L.GML.Geometry.extend({
+
+  elementTag: 'gml:MultiGeometry',
+
   includes: [L.GML.ParserContainerMixin, L.GML.CoordsToLatLngMixin],
 
   initialize: function () {
     this.initializeParserContainer();
+    this.appendParser(new L.GML.Point());
+    this.appendParser(new L.GML.LineString());
+    this.appendParser(new L.GML.Polygon());
   },
 
   /**
@@ -58,6 +64,6 @@ L.GML.MultiGeometry = L.GML.Geometry.extend({
       }
     }
 
-    return this.transform(childObjects, options);
+    return childObjects;
   }
 });

--- a/src/Request.js
+++ b/src/Request.js
@@ -2,7 +2,7 @@
  * Created by PRadostev on 02.02.2015.
  */
 
-L.Util.request = function (options) {
+L.Util.request = function (options, xhrReferenceCallback) {
   options = L.extend({
     async: true,
     method: 'POST',
@@ -24,6 +24,10 @@ L.Util.request = function (options) {
 
   // good bye IE 6,7
   var xhr = new XMLHttpRequest();
+
+  if (xhrReferenceCallback) {
+    xhrReferenceCallback(xhr);
+  }
 
   xhr.onreadystatechange = function () {
     if (xhr.readyState === 4) {

--- a/src/WFS.js
+++ b/src/WFS.js
@@ -35,6 +35,8 @@ L.WFS = L.FeatureGroup.extend({
 
   state: {},
 
+  xhr: null,
+
   initialize: function (options, readFormat) {
     L.setOptions(this, options);
 
@@ -191,6 +193,8 @@ L.WFS = L.FeatureGroup.extend({
 
         return that;
       }
+    }, function(xhr) {
+      that.xhr = xhr;
     });
   },
 

--- a/src/WFS.js
+++ b/src/WFS.js
@@ -169,7 +169,14 @@ L.WFS = L.FeatureGroup.extend({
             if (element.setStyle) {
               element.setStyle(that.options.style(element));
             }
-            that.addLayer(element);
+
+            if (Array.isArray(element)) {
+              for (var i = 0 ; i < element.length ; i++) {
+                that.addLayer(element[i]);
+              }
+            } else {
+              that.addLayer(element);
+            }
           });
         } else {
           layers.forEach(function (element) {


### PR DESCRIPTION
The library fails when a WFS document contains gml:MultiGeometry element. This PR adds support of it.